### PR TITLE
Add `info` field to `Code` block

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ line is stored as the info string, both are null if missing)
 interface Code <: Text {
   type: "code";
   lang: string | null;
-  infoString: string | null;
+  info: string | null;
 }
 ```
 
@@ -183,7 +183,7 @@ Yields:
 {
   "type": "code",
   "lang": null,
-  "infoString": null,
+  "info": null,
   "value": "foo()"
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -157,14 +157,17 @@ Yields:
 ### `Code`
 
 `Code` ([`Text`][text]) occurs at block level (see
-[`InlineCode`][inlinecode] for code spans).  `Code` sports a language
-tag (when using GitHub Flavoured Markdown fences with a flag, `null`
-otherwise).
+[`InlineCode`][inlinecode] for code spans).  `Code` supports an
+info string and a language tag (when the line with the opening fence
+contains some text, it is stored as the info string, the first word
+following the fence is stored as the language tag, the rest of the
+line is stored as the info string, both are null if missing)
 
 ```idl
 interface Code <: Text {
   type: "code";
   lang: string | null;
+  infoString: string | null;
 }
 ```
 
@@ -180,6 +183,7 @@ Yields:
 {
   "type": "code",
   "lang": null,
+  "infoString": null,
   "value": "foo()"
 }
 ```


### PR DESCRIPTION
Hi :)


It's just an update of the Code's description. The main modification is the info string tag.

Double check my english please. :pray: 

:two_hearts: 