### PR TITLE
Fix example of `image` node

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -938,7 +938,7 @@ Yields:
 ```javascript
 {
   type: 'image',
-  url: 'http://example.com',
+  url: 'http://example.com/favicon.ico',
   title: 'bravo',
   alt: 'alpha'
 }


### PR DESCRIPTION
As far as I can tell, the `url` property of this documentation of an image should be the image's URL - fixed it!