### PR TITLE
Add mdast-builder to utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1315,6 +1315,8 @@ See the [unist list of utilities][utilities] for more utilities.
     — Assert nodes
 *   [`mdast-add-list-metadata`](https://gitlab.com/staltz/mdast-add-list-metadata)
     — Enhances the metadata of list and listItem nodes
+*   [`mdast-builder`](https://github.com/mike-north/mdast-builder)
+    — Build mdast structures with composable functions
 *   [`mdast-comment-marker`](https://github.com/syntax-tree/mdast-comment-marker)
     — Parse a comment marker
 *   [`mdast-util-compact`](https://github.com/syntax-tree/mdast-util-compact)
@@ -1351,8 +1353,6 @@ See the [unist list of utilities][utilities] for more utilities.
     — Transform to NLCST
 *   [`mdast-zone`](https://github.com/syntax-tree/mdast-zone)
     — HTML comments as ranges or markers
-*   [`mdast-builder`](https://github.com/mike-north/mdast-builder)
-    — Build mdast structures with composable functions
 
 ## References
 

--- a/readme.md
+++ b/readme.md
@@ -1351,6 +1351,8 @@ See the [unist list of utilities][utilities] for more utilities.
     — Transform to NLCST
 *   [`mdast-zone`](https://github.com/syntax-tree/mdast-zone)
     — HTML comments as ranges or markers
+*   [`mdast-builder`](https://github.com/mike-north/mdast-builder)
+    — Build mdast structures with composable functions
 
 ## References
 


### PR DESCRIPTION
Per suggestion from @wooorm, adding [mdast-builder](https://github.com/mike-north/mdast-builder) to the list of utilities.