### PR TITLE
Add `mdast-util-from-adf` to list of utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1390,6 +1390,8 @@ See the [unist list of utilities][utilities] for more utilities.
     — Flatten listItem and (nested) paragraph into one listItem node
 *   [`mdast-flatten-nested-lists`](https://gitlab.com/staltz/mdast-flatten-nested-lists)
     — Transforms a tree to avoid lists inside lists
+*   [`mdast-util-from-adf`](https://github.com/bitcrowd/mdast-util-from-adf)
+    — Build mdast sytax tree from Atlassian Document Format (ADF)
 *   [`mdast-util-heading-range`](https://github.com/syntax-tree/mdast-util-heading-range)
     — Markdown heading as ranges
 *   [`mdast-util-heading-style`](https://github.com/syntax-tree/mdast-util-heading-style)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Hi 👋 

First off, thanks a ton for this great tool 💚 

This PR adds the [mdast-util-from-adf](https://github.com/bitcrowd/mdast-util-from-adf) package to the list of utilities in the readme.

The `mdast-util-from-adf` package is a utility to build a mdast syntax tree from [Atlassian Document format (ADF)](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/). ADF is a rich text format which Atlassian uses in most of its products (e.g. Jira, Confluence, etc.). It is _"close"_ to Markdown, but not 100%. Combining this utility package with `mdast-util-to-markdown` allows escaping Atlassian's proprietary gardens into the freedom of widely used formats 🦋.

Background: My former colleague @pmeinhardt wrote the package to parse Jira tickets into Git commit messages and format them reasonably. It is used as part of a browser extension for Git conventions (https://github.com/bitcrowd/tickety-tick).

Maybe this package is helpful for others who are struggling with ADF as well ☮️
<!--do not edit: pr-->
