### PR TITLE
Add a reference to `mdast-util-hidden`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1421,6 +1421,8 @@ See the [unist list of utilities][utilities] for more utilities.
     — get the plain text content of a node
 *   [`mdast-zone`](https://github.com/syntax-tree/mdast-zone)
     — HTML comments as ranges or markers
+*   [`mdast-util-hidden`](https://github.com/Xunnamius/unified-utils/tree/main/packages/mdast-util-hidden)
+    — prevent nodes from being seen by transformers.
 
 ## References
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Available here: https://github.com/Xunnamius/unified-utils/tree/main/packages

This is a utility that lets you hide mdast nodes from transforms (i.e. stash them away as the "hidden children" of a `Hidden` node) and then reveal them later.

Useful for plugins like [remark-ignore](https://github.com/Xunnamius/unified-utils/blob/main/packages/remark-ignore) and [remark-renumber-references](https://github.com/Xunnamius/unified-utils/blob/main/packages/remark-renumber-references) where it's necessary to hide nodes while executing third-party/vendor transformations.

<!--do not edit: pr-->
