### PR TITLE
Fix typo in `code` example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ Yields:
 ```js
 {
   type: 'code',
-  lang: 'javascript',
+  lang: 'js',
   meta: 'highlight-line="2"',
   value: 'foo()\nbar()\nbaz()'
 }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Example says
````markdown
```js highlight-line="2"
foo()
bar()
baz()
```
````
Yields:

```js
{
  type: 'code',
  lang: 'javascript',
  meta: 'highlight-line="2"',
  value: 'foo()\nbar()\nbaz()'
}
```

but it should say `lang: 'js'`

<!--do not edit: pr-->
